### PR TITLE
Reworked "Organization" in AdminData

### DIFF
--- a/schema/ODM-admindata.xsd
+++ b/schema/ODM-admindata.xsd
@@ -17,15 +17,37 @@
     <xs:attributeGroup name="UserAttributeDefinition">
         <xs:attribute name="OID" type="oid" use="required"/>
         <xs:attribute name="UserType" type="UserType"/>
+        <xs:attribute name="OrganizationOID" type="oidref"/>
+        <xs:attribute name="LocationOID" type="oidref"/> 
     </xs:attributeGroup>
     <xs:attributeGroup name="LocationAttributeDefinition">
         <xs:attribute name="OID" type="oid" use="required"/>
         <xs:attribute name="Name" type="name" use="required"/>
-        <xs:attribute name="LocationType" type="LocationType"/>
+        <!--xs:attribute name="LocationType" type="LocationType"/-->
+        <xs:attribute name="Role" type="text"></xs:attribute>
+        <xs:attribute name="OrganizationOID" type="oidref"/>
     </xs:attributeGroup>
+    <xs:attributeGroup name="OrganizationAttributeDefinition">
+        <xs:attribute name="OID" type="oid" use="required"/>
+        <xs:attribute name="Name" type="name" use="required"/>
+        <xs:attribute name="Type" type="OrganizationType" use="required"/>
+        <xs:attribute name="LocationOID" type="oidref"/>
+        <xs:attribute name="PartOfOrganizationOID" type="oidref"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="GeoPositionAttributeDefinition">
+        <xs:attribute name="Longitude" type="decimal"/>
+        <xs:attribute name="Latitude" type="decimal"/>
+        <xs:attribute name="Altitude" type="decimal"/>
+    </xs:attributeGroup>
+    <!-- TODO: is this still used? -->
     <xs:attributeGroup name="PictureAttributeDefinition">
         <xs:attribute name="PictureFileName" type="fileName" use="required"/>
         <xs:attribute name="ImageType" type="name"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="ImageAttributeDefinition">
+        <xs:attribute name="ImageFileName" type="fileName"/>
+        <xs:attribute name="href" type="text"/>
+        <xs:attribute name="MimeType" type="text"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="SignatureDefAttributeDefinition">
         <xs:attribute name="OID" type="oid" use="required"/>
@@ -45,6 +67,7 @@
     <xs:complexType name="ODMcomplexTypeDefinition-AdminData">
         <xs:sequence>
             <xs:element ref="User" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="Organization" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element ref="Location" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element ref="SignatureDef" minOccurs="0" maxOccurs="unbounded"/>
             <xs:group ref="AdminDataElementExtension" minOccurs="0" maxOccurs="unbounded"/>
@@ -54,34 +77,54 @@
     </xs:complexType>
     <xs:complexType name="ODMcomplexTypeDefinition-User">
         <xs:sequence>
-            <xs:element ref="LoginName" minOccurs="0"/>
-            <xs:element ref="DisplayName" minOccurs="0"/>
+            <xs:element ref="UserName" minOccurs="0"/>
+            <!--xs:element ref="DisplayName" minOccurs="0"/-->
+            <xs:element ref="Prefix" minOccurs="0"/>
+            <xs:element ref="Suffix" minOccurs="0"/>
             <xs:element ref="FullName" minOccurs="0"/>
-            <xs:element ref="FirstName" minOccurs="0"/>
-            <xs:element ref="LastName" minOccurs="0"/>
-            <xs:element ref="Organization" minOccurs="0"/>
+            <!--xs:element ref="FirstName" minOccurs="0"/-->
+            <xs:element ref="GivenName" minOccurs="0"/>
+            <!--xs:element ref="LastName" minOccurs="0"/-->
+            <xs:element ref="FamilyName" minOccurs="0"/>
+            <xs:element ref="Image" minOccurs="0"/>
+            <!--xs:element ref="Organization" minOccurs="0"/-->
             <xs:element ref="Address" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="Email" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="Pager" minOccurs="0"/>
-            <xs:element ref="Fax" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="Phone" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="LocationRef" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="Telecom" minOccurs="0" maxOccurs="unbounded"/>
+            <!--xs:element ref="Email" minOccurs="0" maxOccurs="unbounded"/-->
+            <!--xs:element ref="Pager" minOccurs="0"/-->
+            <!--xs:element ref="Fax" minOccurs="0" maxOccurs="unbounded"/-->
+            <!--xs:element ref="Phone" minOccurs="0" maxOccurs="unbounded"/-->
+            <!--xs:element ref="LocationRef" minOccurs="0" maxOccurs="unbounded"/-->
             <xs:group ref="UserElementExtension" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attributeGroup ref="UserAttributeDefinition"/>
         <xs:attributeGroup ref="UserAttributeExtension"/>
     </xs:complexType>
-    <xs:complexType name="ODMcomplexTypeDefinition-LoginName">
+    <xs:complexType name="ODMcomplexTypeDefinition-UserName">
         <xs:simpleContent>
             <xs:extension base="text">
-                <xs:attributeGroup ref="LoginNameAttributeExtension"/>
+                <xs:attributeGroup ref="UserNameAttributeExtension"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
-    <xs:complexType name="ODMcomplexTypeDefinition-DisplayName">
+    <!--xs:complexType name="ODMcomplexTypeDefinition-DisplayName">
         <xs:simpleContent>
             <xs:extension base="text">
                 <xs:attributeGroup ref="DisplayNameAttributeExtension"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType-->
+    <xs:complexType name="ODMcomplexTypeDefinition-Prefix">
+        <xs:simpleContent>
+            <xs:extension base="text">
+                <xs:attributeGroup ref="PrefixAttributeExtension"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="ODMcomplexTypeDefinition-Suffix">
+        <xs:simpleContent>
+            <xs:extension base="text">
+                <xs:attributeGroup ref="SuffixAttributeExtension"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
@@ -92,30 +135,58 @@
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
-    <xs:complexType name="ODMcomplexTypeDefinition-FirstName">
+    <!--xs:complexType name="ODMcomplexTypeDefinition-FirstName">
         <xs:simpleContent>
             <xs:extension base="text">
                 <xs:attributeGroup ref="FirstNameAttributeExtension"/>
             </xs:extension>
         </xs:simpleContent>
+    </xs:complexType-->
+    <xs:complexType name="ODMcomplexTypeDefinition-GivenName">
+        <xs:simpleContent>
+            <xs:extension base="text">
+                <xs:attributeGroup ref="GivenNameAttributeExtension"/>
+            </xs:extension>
+        </xs:simpleContent>
     </xs:complexType>
-    <xs:complexType name="ODMcomplexTypeDefinition-LastName">
+    <!--xs:complexType name="ODMcomplexTypeDefinition-LastName">
         <xs:simpleContent>
             <xs:extension base="text">
                 <xs:attributeGroup ref="LastNameAttributeExtension"/>
             </xs:extension>
         </xs:simpleContent>
-    </xs:complexType>
-    <xs:complexType name="ODMcomplexTypeDefinition-Organization">
+    </xs:complexType-->
+    <xs:complexType name="ODMcomplexTypeDefinition-FamilyName">
         <xs:simpleContent>
             <xs:extension base="text">
-                <xs:attributeGroup ref="OrganizationAttributeExtension"/>
+                <xs:attributeGroup ref="FamilyNameAttributeExtension"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
+    <xs:complexType name="ODMcomplexTypeDefinition-Image">
+        <xs:sequence>
+            <xs:group ref="ImageElementExtension" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ImageAttributeDefinition"/>
+        <xs:attributeGroup ref="ImageAttributeExtension"/>
+    </xs:complexType>
+    <xs:complexType name="ODMcomplexTypeDefinition-Organization">
+        <xs:sequence>
+            <xs:element ref="Description" minOccurs="0"/>
+            <xs:element ref="Address" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="Telecom" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:group ref="OrganizationElementExtension" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="OrganizationAttributeDefinition"/>
+        <xs:attributeGroup ref="OrganizationAttributeExtension"/>
+    </xs:complexType>
     <xs:complexType name="ODMcomplexTypeDefinition-Location">
         <xs:sequence>
+            <xs:element ref="Description" minOccurs="0"/>
             <xs:element ref="MetaDataVersionRef" maxOccurs="unbounded"/>
+            <xs:element ref="Address" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="Telecom" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="Query" minOccurs="0" maxOccurs="unbounded"/>
             <xs:group ref="LocationElementExtension" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attributeGroup ref="LocationAttributeDefinition"/>
@@ -123,20 +194,36 @@
     </xs:complexType>
     <xs:complexType name="ODMcomplexTypeDefinition-Address">
         <xs:sequence>
-            <xs:element ref="StreetName" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="StreetName" minOccurs="0"/>
+            <xs:element ref="HouseNumber" minOccurs="0"/>
             <xs:element ref="City" minOccurs="0"/>
             <xs:element ref="StateProv" minOccurs="0"/>
             <xs:element ref="Country" minOccurs="0"/>
             <xs:element ref="PostalCode" minOccurs="0"/>
+            <xs:element ref="GeoPosition" minOccurs="0"/>
             <xs:element ref="OtherText" minOccurs="0"/>
             <xs:group ref="AddressElementExtension" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attributeGroup ref="AddressAttributeExtension"/>
     </xs:complexType>
+    <xs:complexType name="ODMcomplexTypeDefinition-Telecom">
+        <xs:sequence>
+            <xs:group ref="TelecomElementExtension" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="TelecomType" type="TelecomTypeType" use="required"/>
+        <xs:attribute name="Value" type="text" use="required"/>
+    </xs:complexType>
     <xs:complexType name="ODMcomplexTypeDefinition-StreetName">
         <xs:simpleContent>
             <xs:extension base="text">
                 <xs:attributeGroup ref="StreetNameAttributeExtension"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="ODMcomplexTypeDefinition-HouseNumber">
+        <xs:simpleContent>
+            <xs:extension base="text">
+                <xs:attributeGroup ref="HouseNumberAttributeExtension"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
@@ -167,6 +254,13 @@
                 <xs:attributeGroup ref="PostalCodeAttributeExtension"/>
             </xs:extension>
         </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="ODMcomplexTypeDefinition-GeoPosition">
+        <xs:sequence>
+            <xs:group ref="GeoPositionElementExtension" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="GeoPositionAttributeDefinition"/>
+        <xs:attributeGroup ref="GeoPositionAttributeExtension"/>
     </xs:complexType>
     <xs:complexType name="ODMcomplexTypeDefinition-MetaDataVersionRef">
         <xs:sequence>
@@ -254,19 +348,27 @@
         </xs:unique>
     </xs:element>
     <xs:element name="User" type="ODMcomplexTypeDefinition-User"/>
-    <xs:element name="LoginName" type="ODMcomplexTypeDefinition-LoginName"/>
-    <xs:element name="DisplayName" type="ODMcomplexTypeDefinition-DisplayName"/>
+    <xs:element name="UserName" type="ODMcomplexTypeDefinition-UserName"/>
+    <!--xs:element name="DisplayName" type="ODMcomplexTypeDefinition-DisplayName"/-->
+    <xs:element name="Prefix" type="ODMcomplexTypeDefinition-Prefix"/>
+    <xs:element name="Suffix" type="ODMcomplexTypeDefinition-Suffix"></xs:element>
     <xs:element name="FullName" type="ODMcomplexTypeDefinition-FullName"/>
-    <xs:element name="FirstName" type="ODMcomplexTypeDefinition-FirstName"/>
-    <xs:element name="LastName" type="ODMcomplexTypeDefinition-LastName"/>
+    <!--xs:element name="FirstName" type="ODMcomplexTypeDefinition-FirstName"/-->
+    <xs:element name="GivenName" type="ODMcomplexTypeDefinition-GivenName"/>
+    <!--xs:element name="LastName" type="ODMcomplexTypeDefinition-LastName"/-->
+    <xs:element name="FamilyName" type="ODMcomplexTypeDefinition-FamilyName"/>
+    <xs:element name="Image" type="ODMcomplexTypeDefinition-Image"/>
     <xs:element name="Organization" type="ODMcomplexTypeDefinition-Organization"/>
     <xs:element name="Location" type="ODMcomplexTypeDefinition-Location"/>
     <xs:element name="Address" type="ODMcomplexTypeDefinition-Address"/>
+    <xs:element name="Telecom" type="ODMcomplexTypeDefinition-Telecom"/>
     <xs:element name="StreetName" type="ODMcomplexTypeDefinition-StreetName"/>
+    <xs:element name="HouseNumber" type="ODMcomplexTypeDefinition-HouseNumber"/>
     <xs:element name="City" type="ODMcomplexTypeDefinition-City"/>
     <xs:element name="StateProv" type="ODMcomplexTypeDefinition-StateProv"/>
     <xs:element name="Country" type="ODMcomplexTypeDefinition-Country"/>
     <xs:element name="PostalCode" type="ODMcomplexTypeDefinition-PostalCode"/>
+    <xs:element name="GeoPosition" type="ODMcomplexTypeDefinition-GeoPosition"></xs:element>
     <xs:element name="Email" type="ODMcomplexTypeDefinition-Email"/>
     <xs:element name="Pager" type="ODMcomplexTypeDefinition-Pager"/>
     <xs:element name="Fax" type="ODMcomplexTypeDefinition-Fax"/>

--- a/schema/ODM-clinicaldata.xsd
+++ b/schema/ODM-clinicaldata.xsd
@@ -96,6 +96,8 @@
 			<xs:element ref="AuditRecords" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="Signatures" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="Annotations" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="ItemGroupData" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="Query" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:group ref="ClinicalDataElementExtension" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="ClinicalDataAttributeDefinition"/>
@@ -109,6 +111,7 @@
 			<xs:element ref="SiteRef" minOccurs="0"/>
 			<xs:element ref="Annotation" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="StudyEventData" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="Query" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:group ref="SubjectDataElementExtension" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="SubjectDataAttributeDefinition"/>
@@ -134,6 +137,7 @@
 			<xs:element ref="Signature" minOccurs="0"/>
 			<xs:element ref="Annotation" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="ItemGroupData" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="Query" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:group ref="StudyEventDataElementExtension" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="StudyEventDataAttributeDefinition"/>
@@ -145,6 +149,7 @@
 			<xs:element ref="Signature" minOccurs="0"/>
 			<xs:element ref="Annotation" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element ref="ItemData" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="Query" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:group ref="ItemGroupDataElementExtension" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="ItemGroupDataAttributeDefinition"/>
@@ -155,6 +160,7 @@
 			<xs:element ref="AuditRecord" minOccurs="0"/>
 			<xs:element ref="Signature" minOccurs="0"/>
 			<xs:element ref="Annotation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element ref="Query" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:group ref="ItemDataElementExtension" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:attributeGroup ref="ItemDataAttributeSharedDefinition"/>

--- a/schema/ODM-enumerations.xsd
+++ b/schema/ODM-enumerations.xsd
@@ -272,14 +272,42 @@
             <xs:enumeration value="Investigator"/>
             <xs:enumeration value="Lab"/>
             <xs:enumeration value="Other"/>
+            <!-- extended 2022 ODMv2 -->
+            <xs:enumeration value="Subject"/>
+            <xs:enumeration value="Monitor"/>
+            <xs:enumeration value="Data analyst"/>
+            <xs:enumeration value="Care provider"/>
+            <xs:enumeration value="Assessor"/>
         </xs:restriction>
     </xs:simpleType>
+    <!-- Not used anymore
     <xs:simpleType name="LocationType">
         <xs:restriction base="xs:string">
             <xs:enumeration value="Sponsor"/>
             <xs:enumeration value="Site"/>
             <xs:enumeration value="CRO"/>
             <xs:enumeration value="Lab"/>
+            <xs:enumeration value="Other"/>
+        </xs:restriction>
+    </xs:simpleType> -->
+    <xs:simpleType name="OrganizationType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Sponsor"/>
+            <xs:enumeration value="Site"/>
+            <xs:enumeration value="CRO"/>
+            <xs:enumeration value="Lab"/>
+            <xs:enumeration value="Other"/>
+            <xs:enumeration value="TechnologyProvider"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TelecomTypeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Email"/>
+            <xs:enumeration value="Pager"/>
+            <xs:enumeration value="Phone"/>
+            <xs:enumeration value="Fax"/>
+            <xs:enumeration value="SMS"/>
+            <xs:enumeration value="URL"/>
             <xs:enumeration value="Other"/>
         </xs:restriction>
     </xs:simpleType>
@@ -334,6 +362,31 @@
             <xs:enumeration value="Form"/>
             <xs:enumeration value="Dataset"/>
             <xs:enumeration value="Concept"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QuerySourceType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="System"/>
+            <xs:enumeration value="Data Management"/>
+            <xs:enumeration value="Site Monitor"/>
+            <xs:enumeration value="Coding System"/>
+            <xs:enumeration value="Safety Reviewer"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QueryType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Manual"/>
+            <xs:enumeration value="System"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="QueryStateType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Candidate"/>
+            <xs:enumeration value="Open"/>
+            <xs:enumeration value="Answered"/>
+            <xs:enumeration value="Closed"/>
+            <xs:enumeration value="Cancelled"/>
+            <xs:enumeration value="Resolved"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/schema/ODM-foundation.xsd
+++ b/schema/ODM-foundation.xsd
@@ -75,6 +75,18 @@
 		<xs:attribute name="href" type="xs:anyURI" use="optional"/>
 		<xs:attribute name="CommentOID" type="text" use="optional"/>
 	</xs:attributeGroup>
+	<xs:attributeGroup name="QueryAttributeDefinition">
+		<xs:attribute name="OID" type="oid" use="required"/>
+		<xs:attribute name="Source" type="QuerySourceType" use="required"/>
+		<xs:attribute name="Target" type="text"/>
+		<xs:attribute name="Type" type="QueryType"/>
+		<xs:attribute name="State" type="QueryStateType" use="required"/>
+		<xs:attribute name="LastUpdateDatetime" type="datetime" use="required"/>
+		<xs:attribute name="Name" type="name"/>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="ValueAttributeDefinition">
+		<xs:attribute name="SeqNum" type="positiveInteger"/>
+	</xs:attributeGroup>
 	
 	<!--
         +===========================================================================+
@@ -83,17 +95,24 @@
         +===========================================================================+
     -->
 	<xs:attributeGroup name="TranslatedTextAttributeExtension"/>
-	<xs:attributeGroup name="LoginNameAttributeExtension"/>
-	<xs:attributeGroup name="DisplayNameAttributeExtension"/>
+	<xs:attributeGroup name="UserNameAttributeExtension"/>
+	<!--xs:attributeGroup name="DisplayNameAttributeExtension"/-->
+	<xs:attributeGroup name="PrefixAttributeExtension"/>
+	<xs:attributeGroup name="SuffixAttributeExtension"/>
 	<xs:attributeGroup name="FullNameAttributeExtension"/>
-	<xs:attributeGroup name="FirstNameAttributeExtension"/>
-	<xs:attributeGroup name="LastNameAttributeExtension"/>
+	<xs:attributeGroup name="GivenNameAttributeExtension"/>
+	<!--xs:attributeGroup name="FirstNameAttributeExtension"/-->
+	<!--xs:attributeGroup name="LastNameAttributeExtension"/-->
+	<xs:attributeGroup name="FamilyNameAttributeExtension"/>
+	<xs:attributeGroup name="ImageAttributeExtension"/>
 	<xs:attributeGroup name="OrganizationAttributeExtension"/>
 	<xs:attributeGroup name="StreetNameAttributeExtension"/>
+	<xs:attributeGroup name="HouseNumberAttributeExtension"/>
 	<xs:attributeGroup name="CityAttributeExtension"/>
 	<xs:attributeGroup name="StateProvAttributeExtension"/>
 	<xs:attributeGroup name="CountryAttributeExtension"/>
 	<xs:attributeGroup name="PostalCodeAttributeExtension"/>
+	<xs:attributeGroup name="GeoPositionAttributeExtension"/>
 	<xs:attributeGroup name="OtherTextAttributeExtension"/>
 	<xs:attributeGroup name="EmailAttributeExtension"/>
 	<xs:attributeGroup name="PagerAttributeExtension"/>
@@ -209,6 +228,8 @@
 	<xs:attributeGroup name="ParameterAttributeExtension"/>
 	<xs:attributeGroup name="ReturnValueAttributeExtension"/>
 	<xs:attributeGroup name="CommentDefAttributeExtension"/>
+	<xs:attributeGroup name="QueryAttributeExtension"/>
+	<xs:attributeGroup name="ValueAttributeExtension"/>
 	<!--
         +===========================================================================+
         | these are purposely empty modelGroups to permit vendor extensions to the  |
@@ -234,6 +255,12 @@
 		<xs:sequence/>
 	</xs:group>
 	<xs:group name="ExternalCodeListElementExtension">
+		<xs:sequence/>
+	</xs:group>
+	<xs:group name="OrganizationElementExtension">
+		<xs:sequence/>
+	</xs:group>
+	<xs:group name="ImageElementExtension">
 		<xs:sequence/>
 	</xs:group>
 	<xs:group name="LocationRefElementExtension">
@@ -440,6 +467,12 @@
 	<xs:group name="LocationElementExtension">
 		<xs:sequence/>
 	</xs:group>
+	<xs:group name="TelecomElementExtension">
+		<xs:sequence/>
+	</xs:group>
+	<xs:group name="GeoPositionElementExtension">
+		<xs:sequence/>
+	</xs:group>
 	<xs:group name="SignatureDefElementExtension">
 		<xs:sequence/>
 	</xs:group>
@@ -507,6 +540,9 @@
 		<xs:sequence/>
 	</xs:group>
 	<xs:group name="CommentDefElementExtension">
+		<xs:sequence/>
+	</xs:group>
+	<xs:group name="QueryElementExtension">
 		<xs:sequence/>
 	</xs:group>
 	<!--
@@ -586,6 +622,23 @@
 		<xs:attributeGroup ref="CodingAttributeDefinition"/>
 		<xs:attributeGroup ref="CodingAttributeExtension"/>
 	</xs:complexType>
+	<xs:complexType name="ODMcomplexTypeDefinition-Query">
+		<xs:sequence>
+			<xs:element ref="Value"/>
+			<xs:element ref="AuditRecord" minOccurs="0"/>
+			<xs:group ref="QueryElementExtension"></xs:group>
+		</xs:sequence>
+		<xs:attributeGroup ref="QueryAttributeDefinition"/>
+		<xs:attributeGroup ref="QueryAttributeExtension"/>
+	</xs:complexType>
+	<xs:complexType name="ODMcomplexTypeDefinition-Value">
+		<xs:simpleContent>
+			<xs:extension base="text">
+				<xs:attributeGroup ref="ValueAttributeDefinition"/>
+				<xs:attributeGroup ref="ValueAttributeExtension"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	
 
 	<!--
@@ -622,5 +675,7 @@
 	<xs:element name="FlagValue" type="ODMcomplexTypeDefinition-FlagValue"/>
 	<xs:element name="FlagType" type="ODMcomplexTypeDefinition-FlagType"/>
 	<xs:element name="Coding" type="ODMcomplexTypeDefinition-Coding"/>
+	<xs:element name="Query" type="ODMcomplexTypeDefinition-Query"/>
+	<xs:element name="Value" type="ODMcomplexTypeDefinition-Value"/>
 	
 </xs:schema>


### PR DESCRIPTION
Reworked "Organization" and "User" in AdminData and references to it.
Added "Query" and "Value" in odm-foundation.xsd and added references to it in the other schemas.
NOT DONE: replacing "Value" as attribute by "Value" as child element in AdminData